### PR TITLE
Add unanswered question warning

### DIFF
--- a/app.js
+++ b/app.js
@@ -156,6 +156,10 @@
     function loadQuestion(num) {
         const questao = questoes[num - 1];
         const alternativasContainer = document.getElementById('alternativas-container');
+        const questionContainer = document.querySelector('.questao-container');
+        if (questionContainer) questionContainer.classList.remove('unanswered');
+        const warningEl = document.getElementById('unanswered-warning');
+        if (warningEl) warningEl.classList.add('hidden');
         document.getElementById('questao-numero').textContent = num;
         document.getElementById('questao-texto').textContent = questao.pergunta;
         alternativasContainer.innerHTML = '';
@@ -181,6 +185,8 @@
                 } else {
                     respostasFinal[num - 1] = letter;
                 }
+                if (questionContainer) questionContainer.classList.remove('unanswered');
+                if (warningEl) warningEl.classList.add('hidden');
                 updateNavigationButtons();
                 salvarProgresso();
             });
@@ -267,6 +273,13 @@
             currentQuestion = unansweredQuestions + 1;
             loadQuestion(currentQuestion);
             updateProgress();
+            const questionContainer = document.querySelector('.questao-container');
+            const warningEl = document.getElementById('unanswered-warning');
+            if (questionContainer) questionContainer.classList.add('unanswered');
+            if (warningEl) {
+                warningEl.textContent = 'Responda esta questão antes de continuar.';
+                warningEl.classList.remove('hidden');
+            }
             return;
         }
         if (avaliacaoAtual === 'inicial') {

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
                     <div class="questao-content">
                         <h3 id="questao-texto"></h3>
                         <div class="alternativas" id="alternativas-container"></div>
+                        <div id="unanswered-warning" class="unanswered-warning hidden"></div>
                     </div>
                 </div>
 

--- a/style.css
+++ b/style.css
@@ -873,6 +873,17 @@ select.form-control {
   box-shadow: var(--shadow-sm);
 }
 
+.questao-container.unanswered {
+  border-color: var(--color-warning);
+  box-shadow: 0 0 0 2px rgba(var(--color-warning-rgb), 0.4);
+}
+
+.unanswered-warning {
+  color: var(--color-warning);
+  font-size: var(--font-size-sm);
+  margin-top: var(--space-8);
+}
+
 .questao-numero {
   display: inline-block;
   background: var(--color-primary);


### PR DESCRIPTION
## Summary
- signal unanswered questions in the UI
- hide warning after selecting an answer
- style warning text and highlight border

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aab5df3648320abb0259b88f77880