### PR TITLE
Add Jest testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Sistema Provas
+
+Este projeto contém uma aplicação de avaliação em JavaScript.
+
+## Executando os testes
+
+Instale as dependências e execute o Jest:
+
+```bash
+npm install
+npm test
+```

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,0 +1,34 @@
+const { calculateScore, calcularEficacia } = require('../app');
+
+describe('calculateScore', () => {
+  const gabarito = ["C","C","C","B","C","C","C","B","C","C"];
+
+  test('returns full score when all answers correct', () => {
+    expect(calculateScore(gabarito)).toBe(10);
+  });
+
+  test('returns partial score for partially correct answers', () => {
+    const respostas = [...gabarito];
+    respostas[5] = 'A';
+    respostas[6] = 'A';
+    respostas[7] = 'A';
+    respostas[8] = 'A';
+    respostas[9] = 'A';
+    expect(calculateScore(respostas)).toBe(5);
+  });
+});
+
+describe('calcularEficacia', () => {
+  test('calculates positive efficacy', () => {
+    expect(calcularEficacia(5, 8, 10)).toBe(60);
+  });
+
+  test('returns zero when efficacy is negative', () => {
+    expect(calcularEficacia(8, 5, 10)).toBe(0);
+  });
+
+  test('returns zero when any note is null', () => {
+    expect(calcularEficacia(null, 5, 10)).toBe(0);
+    expect(calcularEficacia(5, null, 10)).toBe(0);
+  });
+});

--- a/app.js
+++ b/app.js
@@ -191,7 +191,7 @@
 
     function calculateScore(respostas) {
         let score = 0;
-        for (let i = 0; i < totalQuestions; i++) {
+        for (let i = 0; i < gabarito.length; i++) {
             if (respostas[i] === gabarito[i]) score++;
         }
         return score;
@@ -333,5 +333,12 @@
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { calculateScore, calcularEficacia };
+    } else {
+        window.calculateScore = calculateScore;
+        window.calcularEficacia = calcularEficacia;
     }
 })();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sistema-provas",
+  "version": "1.0.0",
+  "description": "Sistema de provas",
+  "main": "app.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Jest with package.json
- expose functions from `app.js` for Node
- add unit tests for `calculateScore` and `calcularEficacia`
- document how to run tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aab505498832090619c1bf3ba0a4f