### PR TITLE
Add configurable attempt limits per module

### DIFF
--- a/README_auditoria.md
+++ b/README_auditoria.md
@@ -130,6 +130,30 @@ O sistema é robusto e funcional, mas pode evoluir muito em acessibilidade, expe
 
 ---
 
+### Configurações por Módulo
+
+Cada item do array `modulesConfig` pode definir opções de tentativas e tempo de espera entre elas:
+
+- `finalDelayHours`: quantidade de horas que o usuário deve aguardar para refazer o módulo (padrão `24`).
+- `maxAttempts`: número máximo de tentativas permitidas por CPF (padrão `3`).
+
+Exemplo:
+
+```js
+const modulesConfig = [
+  {
+    key: 'seguranca',
+    name: 'Módulo 1 - Segurança do Trabalho',
+    jsonPath: 'questoes_soc.json',
+    active: true,
+    finalDelayHours: 24,
+    maxAttempts: 3
+  }
+];
+```
+
+---
+
 ## Como criar a tabela de resultados no Supabase
 
 Você pode criar a tabela `resultados` diretamente pelo SQL do Supabase.  

--- a/app.js
+++ b/app.js
@@ -31,7 +31,9 @@
             description: 'Sistema de avaliação de eficácia em Segurança Ocupacional e Saúde (SOC)',
             jsonPath: 'questoes_soc.json',
             icon: '🛡️',
-            active: true
+            active: true,
+            finalDelayHours: 24,
+            maxAttempts: 3
         },
         {
             key: 'saude',
@@ -39,7 +41,9 @@
             description: 'Avaliação de programas de saúde ocupacional e medicina do trabalho',
             jsonPath: 'questoes_saude.json',
             icon: '🏥',
-            active: false
+            active: false,
+            finalDelayHours: 24,
+            maxAttempts: 3
         },
         {
             key: 'financeiro',
@@ -47,7 +51,9 @@
             description: 'Gestão financeira e análise de custos em segurança do trabalho',
             jsonPath: 'questoes_financeiro.json',
             icon: '💰',
-            active: false
+            active: false,
+            finalDelayHours: 24,
+            maxAttempts: 3
         }
     ];
 
@@ -265,12 +271,22 @@
                 alert("Por favor, digite um CPF válido (apenas números, 11 dígitos).");
                 return;
             }
-            // Limite de tentativas por CPF, exceto para master
+            // Limite de tentativas por CPF e intervalo mínimo entre elas
             if (userCPF !== MASTER_CPF) {
-                const tentativas = getTentativasCPF(userCPF, currentModule ? currentModule.key : "");
-                if (tentativas >= 3) {
-                    alert("Limite de 3 tentativas atingido para este CPF neste módulo.");
+                const { count: tentativas, lastDate } = getTentativasCPF(userCPF, currentModule ? currentModule.key : "");
+                const maxAttempts = currentModule && currentModule.maxAttempts ? currentModule.maxAttempts : 3;
+                const delayHours = currentModule && currentModule.finalDelayHours ? currentModule.finalDelayHours : 24;
+                if (tentativas >= maxAttempts) {
+                    alert(`Limite de ${maxAttempts} tentativas atingido para este CPF neste módulo.`);
                     return;
+                }
+                if (lastDate) {
+                    const diffHours = (Date.now() - lastDate.getTime()) / 36e5;
+                    if (diffHours < delayHours) {
+                        const restante = Math.ceil(delayHours - diffHours);
+                        alert(`É necessário aguardar ${delayHours} horas entre tentativas. Tente novamente em aproximadamente ${restante} hora(s).`);
+                        return;
+                    }
                 }
             }
             avaliacaoAtual = 'inicial';
@@ -726,7 +742,12 @@
 
     function getTentativasCPF(cpf, moduloKey) {
         const hist = JSON.parse(localStorage.getItem('historicoAvaliacao') || "[]");
-        return hist.filter(h => h.cpf === cpf && h.moduloKey === moduloKey).length;
+        const registros = hist.filter(h => h.cpf === cpf && h.moduloKey === moduloKey);
+        const last = registros[registros.length - 1];
+        return {
+            count: registros.length,
+            lastDate: last ? new Date(last.data) : null
+        };
     }
 
     // Supabase config


### PR DESCRIPTION
## Summary
- allow modules to define `finalDelayHours` and `maxAttempts`
- enforce per-module limits and delay when starting a new attempt
- expose last attempt info from `getTentativasCPF`
- document new module settings

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_685d34d43b008320ac5f27d517a7e193